### PR TITLE
Restore device page watermark

### DIFF
--- a/samples/bluemixZoneDemo/static/stylesheets/device.css
+++ b/samples/bluemixZoneDemo/static/stylesheets/device.css
@@ -67,6 +67,7 @@ input#pin{
 
 .watermark {
 	position: absolute;
+	z-index: -1;
 	width: 100%;
 	left: -20px;
 	top: 10px;

--- a/samples/bluemixZoneDemo/views/device.tpl
+++ b/samples/bluemixZoneDemo/views/device.tpl
@@ -11,6 +11,7 @@
 	</script>
 	
 	<div class="outer-main">
+		<img class="watermark" src="/static/images/bg.svg" />
 		<div class="trail left"></div>
 		<div class="trail right"></div>
 		<img class="plane left" src="/static/images/plane.svg" />


### PR DESCRIPTION
The watermark of the device page was previously removed due to it
appearing on front of the text box. Re-add, behind.