### PR TITLE
Add manifest.yml

### DIFF
--- a/samples/bluemixZoneDemo/README.md
+++ b/samples/bluemixZoneDemo/README.md
@@ -33,7 +33,7 @@ $ cd iot-python/samples/bluemixZoneDemo
 
 ###Create a new application
 ```bash
-$ cf push <app_name> -m 32M -b https://github.com/cloudfoundry/cf-buildpack-python.git --no-start
+$ cf push <app_name> --no-start
 ```
 
 ###Create the required services
@@ -50,7 +50,7 @@ $ cf bind-service <app_name> iotdemo-cloudant
 
 ###Start the application
 ```
-cf push <app_name> -c "python server.py"
+cf push <app_name>
 ```
 ###Launch your application
 

--- a/samples/bluemixZoneDemo/manifest.yml
+++ b/samples/bluemixZoneDemo/manifest.yml
@@ -1,0 +1,6 @@
+applications:
+- command: python server.py
+  path: .
+  instances: 1
+  memory: 32M
+  buildpack: https://github.com/cloudfoundry/cf-buildpack-python.git


### PR DESCRIPTION
Add manifest.yml to the root of the cf part of the demo. This allows the cf push command to be simplified to just include the app name.