### PR TITLE
Remove log and raise exception mangling

### DIFF
--- a/src/ibmiotf/__init__.py
+++ b/src/ibmiotf/__init__.py
@@ -116,7 +116,7 @@ class AbstractClient:
 
 		self.start = time.time()
 
-	def __logAndRaiseException(self, e):
+	def logAndRaiseException(self, e):
 		self.logger.critical(str(e))
 		raise e
 	
@@ -127,11 +127,11 @@ class AbstractClient:
 			self.client.connect(self.address, port=self.port, keepalive=self.keepAlive)
 			self.client.loop_start()
 			if not self.connectEvent.wait(timeout=10):
-				self.__logAndRaiseException(ConnectionException("Operation timed out connecting to the IBM Internet of Things service: %s" % (self.address)))
+				self.logAndRaiseException(ConnectionException("Operation timed out connecting to the IBM Internet of Things service: %s" % (self.address)))
 				
 		except socket.error as serr:
 			self.client.loop_stop()
-			self.__logAndRaiseException(ConnectionException("Failed to connect to the IBM Internet of Things service: %s - %s" % (self.address, str(serr))))
+			self.logAndRaiseException(ConnectionException("Failed to connect to the IBM Internet of Things service: %s - %s" % (self.address, str(serr))))
 
 	def disconnect(self):
 		#self.logger.info("Closing connection to the IBM Internet of Things Foundation")

--- a/src/ibmiotf/application.py
+++ b/src/ibmiotf/application.py
@@ -191,9 +191,9 @@ class Client(ibmiotf.AbstractClient):
 			self.connectEvent.set()
 			self.logger.info("Connected successfully: %s" % self.clientId)
 		elif rc == 5:
-			self.__logAndRaiseException(ConnectionException("Not authorized: (%s, %s, %s)" % (self.clientId, self.username, self.password)))
+			self.logAndRaiseException(ConnectionException("Not authorized: (%s, %s, %s)" % (self.clientId, self.username, self.password)))
 		else:
-			self.__logAndRaiseException(ConnectionException("Connection failed: RC= %s" % (rc)))
+			self.logAndRaiseException(ConnectionException("Connection failed: RC= %s" % (rc)))
 	
 	
 	def subscribeToDeviceEvents(self, deviceType="+", deviceId="+", event="+"):

--- a/src/ibmiotf/device.py
+++ b/src/ibmiotf/device.py
@@ -99,9 +99,9 @@ class Client(ibmiotf.AbstractClient):
 			if self.__options['org'] != "quickstart":
 				self.__subscribeToCommands()
 		elif rc == 5:
-			self.__logAndRaiseException(ConnectionException("Not authorized: s (%s, %s, %s)" % (self.clientId, self.username, self.password)))
+			self.logAndRaiseException(ConnectionException("Not authorized: s (%s, %s, %s)" % (self.clientId, self.username, self.password)))
 		else:
-			self.__logAndRaiseException(ConnectionException("Connection failed: RC= %s" % (rc)))
+			self.logAndRaiseException(ConnectionException("Connection failed: RC= %s" % (rc)))
 	
 
 	def publishEvent(self, event, data, qos=0):


### PR DESCRIPTION
  File "/usr/local/lib/python2.7/dist-packages/paho/mqtt/client.py", line 1887, in _packet_handle
    return self._handle_connack()
  File "/usr/local/lib/python2.7/dist-packages/paho/mqtt/client.py", line 1948, in _handle_connack
    self.on_connect(self, self._userdata, flags_dict, result)
  File "/usr/local/lib/python2.7/dist-packages/ibmiotc/application.py", line 186, in on_connect
    self.__logAndRaiseException(ConnectionException("Not authorized: (%s, %s, %s)" % (self.clientId, self.username, self.password)))
AttributeError: Client instance has no attribute '_Client__logAndRaiseException'

The AbstractClient's __logAndRaiseException attribute is mangled due to double underscore.  Suggest removing them to avoid mangling and make that method generally available (so at least children can safely invoke).