### PR TITLE
Fix long description to point to right file in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url='https://github.com/ibm-messaging/iot-python',
     license=open('LICENSE').read(),
     description='IBM Internet of Things Foundation for Python',
-	long_description=open('README.txt').read(),
+    long_description=open('README.md').read(),
     install_requires=[
         "iso8601 >= 0.1.10",
         "paho-mqtt >= 1.0",


### PR DESCRIPTION
Executing setup.py install fails with error
#setup.py install
Traceback (most recent call last):
  File "C:\2015\learn\iot\iot-python\setup.py", line 20, in <module>
    long_description=open('README.txt').read(),
IOError: [Errno 2] No such file or directory: 'README.txt'